### PR TITLE
Optimizations for ARM Cortex-M4/7/33

### DIFF
--- a/src/Renderer3D.h
+++ b/src/Renderer3D.h
@@ -1831,7 +1831,7 @@ namespace tgx
 
 
         /** used by _discard() for testing a point position against the frustum planes */
-        void _clip(int & fl, const fVec4 & P, float bx, float Bx, float by, float By)
+        TGX_INLINE inline void _clip(int & fl, const fVec4 & P, float bx, float Bx, float by, float By)
             {
             if (P.x >= bx) { fl &= (~(1)); }
             if (P.x <= Bx) { fl &= (~(2)); }
@@ -1843,7 +1843,7 @@ namespace tgx
 
 
         /** used by _discard() for testing a point position against the frustum planes */
-        void _clip(int & fl, const fVec3 & P, float bx, float Bx, float by, float By, const fMat4 & M)
+        TGX_INLINE inline void _clip(int & fl, const fVec3 & P, float bx, float Bx, float by, float By, const fMat4 & M)
             {
             fVec4 S = M.mult1(P);
             if (!_ortho) S.zdivide();
@@ -1858,12 +1858,10 @@ namespace tgx
             if ((bb.minX == 0) && (bb.maxX == 0) && (bb.minY == 0) && (bb.maxY == 0) && (bb.minZ == 0) && (bb.maxZ == 0))
                 return false; // do not discard if the bounding box is uninitialized.
 
-            const float ilx = 2.0f * fast_inv((float)_lx);
-            const float bx = (_ox - 1) * ilx - 1.0f;
-            const float Bx = (_ox + _uni.im->width() + 1) * ilx - 1.0f;
-            const float ily = 2.0f * fast_inv((float)_ly);
-            const float by = (_oy - 1) * ily - 1.0f;
-            const float By = (_oy + _uni.im->height() + 1) * ily - 1.0f;
+            const float bx = (_ox - 1) * _ilx - 1.0f;
+            const float Bx = (_ox + _uni.im->width() + 1) * _ilx - 1.0f;
+            const float by = (_oy - 1) * _ily - 1.0f;
+            const float By = (_oy + _uni.im->height() + 1) * _ily - 1.0f;
 
             int fl = 63; // every bit set
             _clip(fl, fVec3(bb.minX, bb.minY, bb.minZ), bx, Bx, by, By, M);
@@ -1890,12 +1888,10 @@ namespace tgx
          * coords are given after z-divide. */
         bool _discardTriangle(const fVec4 & P1, const fVec4 & P2, const fVec4 & P3)
             {
-            const float ilx = 2.0f  * fast_inv((float)_lx);
-            const float bx = (_ox - 1) * ilx - 1.0f;
-            const float Bx = (_ox + _uni.im->width() + 1) * ilx - 1.0f;
-            const float ily = 2.0f  * fast_inv((float)_ly);
-            const float by = (_oy - 1) * ily - 1.0f;
-            const float By = (_oy + _uni.im->height() + 1) * ily - 1.0f;
+            const float bx = (_ox - 1) * _ilx - 1.0f;
+            const float Bx = (_ox + _uni.im->width() + 1) * _ilx - 1.0f;
+            const float by = (_oy - 1) * _ily - 1.0f;
+            const float By = (_oy + _uni.im->height() + 1) * _ily - 1.0f;
 
             int fl = 63; // every bit set
             _clip(fl, P1, bx, Bx, by, By);
@@ -2052,6 +2048,7 @@ namespace tgx
         // *** general parameters ***
 
         int     _lx, _ly;           // viewport dimension        
+        float   _ilx, _ily;         // inverse viewport dimension
 
         int     _ox, _oy;           // image offset w.r.t. the viewport        
 

--- a/src/Renderer3D.inl
+++ b/src/Renderer3D.inl
@@ -124,6 +124,8 @@ namespace tgx
             {
             _lx = clamp(lx, 0, MAXVIEWPORTDIMENSION);
             _ly = clamp(ly, 0, MAXVIEWPORTDIMENSION);
+            _ilx = _lx ? 2.0f / _lx : 2.0f;
+            _ily = _ly ? 2.0f / _ly : 2.0f;
             }
 
 

--- a/src/Shaders.h
+++ b/src/Shaders.h
@@ -342,8 +342,8 @@ namespace tgx
                     {
                     const float xx = tx * icw;
                     const float yy = ty * icw;                    
-                    const int ttx = (int)floorf(xx);
-                    const int tty = (int)floorf(yy);
+                    const int ttx = lfloorf(xx);
+                    const int tty = lfloorf(yy);
                     const float ax = xx - ttx;
                     const float ay = yy - tty;                    
                     const int minx = (TEXTURE_WRAP ? (ttx & (texsize_x_mm)) : shaderclip(ttx, texsize_x_mm));
@@ -505,8 +505,8 @@ namespace tgx
                     {
                     const float xx = tx * icw;
                     const float yy = ty * icw;                    
-                    const int ttx = (int)floorf(xx);
-                    const int tty = (int)floorf(yy);
+                    const int ttx = lfloorf(xx);
+                    const int tty = lfloorf(yy);
                     const float ax = xx - ttx;
                     const float ay = yy - tty;  
                     const int minx = (TEXTURE_WRAP ? (ttx & (texsize_x_mm)) : shaderclip(ttx, texsize_x_mm));
@@ -911,8 +911,8 @@ namespace tgx
                         {
                         const float xx = tx * icw;
                         const float yy = ty * icw;                    
-                        const int ttx = (int)floorf(xx);
-                        const int tty = (int)floorf(yy);
+                        const int ttx = lfloorf(xx);
+                        const int tty = lfloorf(yy);
                         const float ax = xx - ttx;
                         const float ay = yy - tty;       
                         const int minx = (TEXTURE_WRAP ? (ttx & (texsize_x_mm)) : shaderclip(ttx, texsize_x_mm));
@@ -1088,8 +1088,8 @@ namespace tgx
                         {
                         const float xx = tx * icw;
                         const float yy = ty * icw;                    
-                        const int ttx = (int)floorf(xx);
-                        const int tty = (int)floorf(yy);
+                        const int ttx = lfloorf(xx);
+                        const int tty = lfloorf(yy);
                         const float ax = xx - ttx;
                         const float ay = yy - tty;                    
                         const int minx = (TEXTURE_WRAP ? (ttx & (texsize_x_mm)) : shaderclip(ttx, texsize_x_mm));
@@ -1238,8 +1238,8 @@ namespace tgx
                     {
                     const float xx = tx;
                     const float yy = ty;                    
-                    const int ttx = (int)floorf(xx);
-                    const int tty = (int)floorf(yy);
+                    const int ttx = lfloorf(xx);
+                    const int tty = lfloorf(yy);
                     const float ax = xx - ttx;
                     const float ay = yy - tty;                    
                     const int minx = (TEXTURE_WRAP ? (ttx & (texsize_x_mm)) : shaderclip(ttx, texsize_x_mm));
@@ -1391,8 +1391,8 @@ namespace tgx
                     {
                     const float xx = tx;
                     const float yy = ty;                    
-                    const int ttx = (int)floorf(xx);
-                    const int tty = (int)floorf(yy);
+                    const int ttx = lfloorf(xx);
+                    const int tty = lfloorf(yy);
                     const float ax = xx - ttx;
                     const float ay = yy - tty;                    
                     const int minx = (TEXTURE_WRAP ? (ttx & (texsize_x_mm)) : shaderclip(ttx, texsize_x_mm));
@@ -1560,8 +1560,8 @@ namespace tgx
                         {
                         const float xx = tx;
                         const float yy = ty;                    
-                        const int ttx = (int)floorf(xx);
-                        const int tty = (int)floorf(yy);
+                        const int ttx = lfloorf(xx);
+                        const int tty = lfloorf(yy);
                         const float ax = xx - ttx;
                         const float ay = yy - tty;    
                         const int minx = (TEXTURE_WRAP ? (ttx & (texsize_x_mm)) : shaderclip(ttx, texsize_x_mm));
@@ -1737,8 +1737,8 @@ namespace tgx
                         {
                         const float xx = tx;
                         const float yy = ty;                    
-                        const int ttx = (int)floorf(xx);
-                        const int tty = (int)floorf(yy);                    
+                        const int ttx = lfloorf(xx);
+                        const int tty = lfloorf(yy);
                         const float ax = xx - ttx;
                         const float ay = yy - tty;
                         const int minx = (TEXTURE_WRAP ? (ttx & (texsize_x_mm)) : shaderclip(ttx, texsize_x_mm));
@@ -2192,8 +2192,8 @@ namespace tgx
                 {                         
                 const float xx = tx;
                 const float yy = ty;                    
-                const int ttx = (int)floorf(xx);
-                const int tty = (int)floorf(yy);
+                const int ttx = lfloorf(xx);
+                const int tty = lfloorf(yy);
                 const float ax = xx - ttx;
                 const float ay = yy - tty;                    
 
@@ -2387,8 +2387,8 @@ namespace tgx
                 {                         
                 const float xx = tx;
                 const float yy = ty;                    
-                const int ttx = (int)floorf(xx);
-                const int tty = (int)floorf(yy);
+                const int ttx = lfloorf(xx);
+                const int tty = lfloorf(yy);
                 const float ax = xx - ttx;
                 const float ay = yy - tty;                    
 


### PR DESCRIPTION
This was more difficult than for ESP32, as ARM has hardware instructions for full div and sqrt, and no hardware estimates. But it was a fun challenge.

I developed a new approximation for fast_invsqrt() that is 25% faster and has 2x less error than the original (Quake) algorithm. It is similar, but uses exhaustive-search optimized coefs, and uses the extra degree of freedom to eliminate one of the multiplies (eg. coef constrained to 1.0).

I also replaced fast_inv() with a far more accurate one (~20 bits) that is sufficient to avoid artifacts, and still faster than a hardware division. How much depends on which CPU and compiler flags are used.

Here are error plots of the new approximations. Note that since the result exponent is exact (-E for 1/x, -E/2 for 1/sqrt(x)) the minimax error will just repeat over the full range.
![fast_inv](https://github.com/user-attachments/assets/7faa3c24-3fd6-441d-96a8-ae20f26aaea4)
![fast_rsqrtf](https://github.com/user-attachments/assets/e80cf642-7c51-4a86-a16b-dfd48f2a3a2d)
